### PR TITLE
Spark version 2.1.0 -> 2.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ spName := "springml/spark-salesforce"
 
 spAppendScalaVersion := true
 
-sparkVersion := "2.1.0"
+sparkVersion := "2.2.0"
 
 sparkComponents += "sql"
 


### PR DESCRIPTION
Bump the Spark version up to 2.2.0. This is required for additional CSV support when fetching from Salesforce with CSV content type.