### PR TITLE
Bug fix: chunkSize from Option[String] to String 

### DIFF
--- a/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
@@ -210,7 +210,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
         catch {
           case e: Exception => throw new Exception("chunkSize must be a valid integer")
         }
-        customHeaders += new BasicHeader("Sforce-Enable-PKChunking", s"chunkSize=$chunkSize")
+        customHeaders += new BasicHeader("Sforce-Enable-PKChunking", s"chunkSize=${chunkSize.get}")
       } else {
         customHeaders += new BasicHeader("Sforce-Enable-PKChunking", "true")
       }


### PR DESCRIPTION
`chunkSize` variable is an Option[String]. Need to call `chunkSize.get` to construct the header.