### PR TITLE
Use CSV parser to split rows

### DIFF
--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -105,7 +105,7 @@ case class BulkRelation(
         .sparkSession
         .read
         .option("header", true)
-        .option("inferSchema", true)
+        .option("inferSchema", inferSchema)
         .option("quote", "\"")
         .option("escape", "\"")
         .option("multiLine", true)

--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -10,6 +10,12 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import com.springml.salesforce.wave.model.{BatchInfo, BatchInfoList, JobInfo}
 import org.apache.http.Header
 import org.apache.spark.rdd.RDD
+import com.univocity.parsers.csv.CsvParser
+import com.univocity.parsers.csv.CsvParserSettings
+import com.univocity.parsers.csv.CsvWriterSettings
+import com.univocity.parsers.csv.CsvWriter
+import java.io.StringReader
+import java.io.StringWriter
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
@@ -63,7 +69,31 @@ case class BulkRelation(
 
         val result = bulkAPI.getBatchResult(jobId, batchInfoId, resultIds.get(resultIds.size() - 1))
 
-        result.lines.toList
+        // Use Csv parser to split CSV by rows to cover edge cases (ex. escaped characters, new line within string, etc)
+        def splitCsvByRows(csvString: String): Seq[String] = {
+          // The CsvParser interface only interacts with IO, so StringReader and StringWriter
+          val inputReader = new StringReader(csvString)
+
+          val parserSettings = new CsvParserSettings()
+          parserSettings.setLineSeparatorDetectionEnabled(true)
+          parserSettings.getFormat.setNormalizedNewline(' ')
+
+          val readerParser = new CsvParser(parserSettings)
+          val parsedInput = readerParser.parseAll(inputReader).asScala
+
+          val outputWriter = new StringWriter()
+
+          val writerSettings = new CsvWriterSettings()
+          writerSettings.setQuoteAllFields(true)
+          writerSettings.setQuoteEscapingEnabled(true)
+
+          val writer = new CsvWriter(outputWriter, writerSettings)
+          parsedInput.foreach { writer.writeRow(_) }
+
+          outputWriter.toString.lines.toList
+        }
+
+        splitCsvByRows(result)
       }
 
       val csvData = sqlContext
@@ -71,7 +101,15 @@ case class BulkRelation(
         .parallelize(completedBatchInfoIds)
         .flatMap(fetchBatchInfo).toDS()
 
-      sqlContext.sparkSession.read.option("header", true).option("inferSchema", inferSchema).csv(csvData)
+      sqlContext
+        .sparkSession
+        .read
+        .option("header", true)
+        .option("inferSchema", true)
+        .option("quote", "\"")
+        .option("escape", "\"")
+        .option("multiLine", true)
+        .csv(csvData)
     } else {
       bulkAPI.closeJob(jobId)
       throw new Exception("Job completion timeout")


### PR DESCRIPTION
Use uniVocity CSV parser to split the CSV by row. This is much more error-prone. It covers many edge cases like escaped characters, new line with a string, and etc.