### PR TITLE
Add maxCharsPerColumn parameter for bulk api

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ $ bin/spark-shell --packages com.springml:spark-salesforce_2.11:1.1.3
 * `pkChunking`: (Optional) Flag to enable automatic primary key chunking for bulk query job. This splits bulk queries into separate batches that of the size defined by `chunkSize` option. By default `false` and the default chunk size is 100,000.
 * `chunkSize`: (Optional) The size of the number of records to include in each batch. Default value is 100,000. This option can only be used when `pkChunking` is `true`. Maximum size is 250,000.
 * `timeout`: (Optional) The maximum time spent polling for the completion of bulk query job. This option can only be used when `bulk` is `true`.
+* `maxCharacterSet`(Optional) The maximum length of a column. This option can only be used when `bulk` is `true`. Default value is `4096`.
 * `externalIdFieldName`: (Optional) The name of the field used as the external ID for Salesforce Object. This value is only used when doing an update or upsert. Default "Id".
 * `queryAll`: (Optional) Toggle to retrieve deleted and archived records for SOQL queries. Default value is `false`.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ bin/spark-shell --packages com.springml:spark-salesforce_2.11:1.1.3
 * `pkChunking`: (Optional) Flag to enable automatic primary key chunking for bulk query job. This splits bulk queries into separate batches that of the size defined by `chunkSize` option. By default `false` and the default chunk size is 100,000.
 * `chunkSize`: (Optional) The size of the number of records to include in each batch. Default value is 100,000. This option can only be used when `pkChunking` is `true`. Maximum size is 250,000.
 * `timeout`: (Optional) The maximum time spent polling for the completion of bulk query job. This option can only be used when `bulk` is `true`.
-* `maxCharacterSet`(Optional) The maximum length of a column. This option can only be used when `bulk` is `true`. Default value is `4096`.
+* `maxCharsPerColumn`(Optional) The maximum length of a column. This option can only be used when `bulk` is `true`. Default value is `4096`.
 * `externalIdFieldName`: (Optional) The name of the field used as the external ID for Salesforce Object. This value is only used when doing an update or upsert. Default "Id".
 * `queryAll`: (Optional) Toggle to retrieve deleted and archived records for SOQL queries. Default value is `false`.
 

--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -34,7 +34,8 @@ case class BulkRelation(
     userSchema: StructType,
     sqlContext: SQLContext,
     inferSchema: Boolean,
-    timeout: Long) extends BaseRelation with TableScan {
+    timeout: Long,
+    maxCharacterSize: Int) extends BaseRelation with TableScan {
 
   import sqlContext.sparkSession.implicits._
 
@@ -77,6 +78,7 @@ case class BulkRelation(
           val parserSettings = new CsvParserSettings()
           parserSettings.setLineSeparatorDetectionEnabled(true)
           parserSettings.getFormat.setNormalizedNewline(' ')
+          parserSettings.setMaxCharsPerColumn(maxCharacterSize)
 
           val readerParser = new CsvParser(parserSettings)
           val parsedInput = readerParser.parseAll(inputReader).asScala

--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -35,7 +35,7 @@ case class BulkRelation(
     sqlContext: SQLContext,
     inferSchema: Boolean,
     timeout: Long,
-    maxCharacterSize: Int) extends BaseRelation with TableScan {
+    maxCharsPerColumn: Int) extends BaseRelation with TableScan {
 
   import sqlContext.sparkSession.implicits._
 
@@ -78,7 +78,7 @@ case class BulkRelation(
           val parserSettings = new CsvParserSettings()
           parserSettings.setLineSeparatorDetectionEnabled(true)
           parserSettings.getFormat.setNormalizedNewline(' ')
-          parserSettings.setMaxCharsPerColumn(maxCharacterSize)
+          parserSettings.setMaxCharsPerColumn(maxCharsPerColumn)
 
           val readerParser = new CsvParser(parserSettings)
           val parsedInput = readerParser.parseAll(inputReader).asScala

--- a/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
@@ -190,6 +190,13 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       throw new Exception("sfObject must not be empty when performing bulk query")
     }
 
+    val maxCharacterSizeStr = parameters.getOrElse("maxCharacterSize", "4096")
+    val maxCharacterSize = try {
+      maxCharacterSizeStr.toInt
+    } catch {
+      case e: Exception => throw new Exception("maxCharacterSize must be a valid integer")
+    }
+
     val timeoutStr = parameters.getOrElse("timeout", "600000")
     val timeout = try {
       timeoutStr.toLong
@@ -228,7 +235,8 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       schema,
       sqlContext,
       inferSchemaFlag,
-      timeout
+      timeout,
+      maxCharacterSize
     )
   }
 

--- a/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
@@ -190,11 +190,11 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       throw new Exception("sfObject must not be empty when performing bulk query")
     }
 
-    val maxCharacterSizeStr = parameters.getOrElse("maxCharacterSize", "4096")
-    val maxCharacterSize = try {
-      maxCharacterSizeStr.toInt
+    val maxCharsPerColumnStr = parameters.getOrElse("maxCharsPerColumn", "4096")
+    val maxCharsPerColumn = try {
+      maxCharsPerColumnStr.toInt
     } catch {
-      case e: Exception => throw new Exception("maxCharacterSize must be a valid integer")
+      case e: Exception => throw new Exception("maxCharsPerColumn must be a valid integer")
     }
 
     val timeoutStr = parameters.getOrElse("timeout", "600000")
@@ -236,7 +236,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       sqlContext,
       inferSchemaFlag,
       timeout,
-      maxCharacterSize
+      maxCharsPerColumn
     )
   }
 


### PR DESCRIPTION
* Default string length for Univocity CsvParser is 4096, this extends it to being a parameter