### PR TITLE
Fix the CSV parsing exception when the data in Salesforce containing Big

### DIFF
--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -77,6 +77,7 @@ case class BulkRelation(
           val parserSettings = new CsvParserSettings()
           parserSettings.setLineSeparatorDetectionEnabled(true)
           parserSettings.getFormat.setNormalizedNewline(' ')
+          parserSettings.setMaxCharsPerColumn(-1)
 
           val readerParser = new CsvParser(parserSettings)
           val parsedInput = readerParser.parseAll(inputReader).asScala


### PR DESCRIPTION
What is PR is trying to address:
When the Salesforce Bulk API is enabled, Salesforce will generate the CSV file. If there are big text fields, current internal CSV parser used will fail to handle these Big Text field with the following Exception and Stack-trace:

Caused by: com.univocity.parsers.common.TextParsingException: Length of parsed input (4097) exceeds the maximum number of characters defined in your parser settings (4096). 
Hint: Number of characters processed may have exceeded limit of 4096 characters per column. Use settings.setMaxCharsPerColumn(int) to define the maximum number of characters a column can have
Ensure your configuration is correct, with delimiters, quotes and escape sequences that match the input format you are trying to parse
Parser Configuration: CsvParserSettings:
    Auto configuration enabled=true
    Autodetect column delimiter=false
    Autodetect quotes=false
    Column reordering enabled=true
    Delimiters for detection=null
    Empty value=null
    Escape unquoted values=false
    Header extraction enabled=null
    Headers=null
    Ignore leading whitespaces=true
    Ignore leading whitespaces in quotes=false
    Ignore trailing whitespaces=true
    Ignore trailing whitespaces in quotes=false
    Input buffer size=1048576
    Input reading on separate thread=true
    Keep escape sequences=false
    Keep quotes=false
    Length of content displayed on error=-1
    Line separator detection enabled=true
    Maximum number of characters per column=4096
    Maximum number of columns=512
    Normalize escaped line separators=true
    Null value=null
    Number of records to read=all
    Processor=none
    Restricting data in exceptions=false
    RowProcessor error handler=null
    Selected fields=none
    Skip bits as whitespace=true
    Skip empty lines=true
    Unescaped quote handling=nullFormat configuration:
    CsvFormat:
        Comment character=#
        Field delimiter=,
        Line separator (normalized)= 
        Line separator sequence=\n
        Quote character="
        Quote escape character="
        Quote escape escape character=null
    at com.univocity.parsers.common.AbstractParser.handleException(AbstractParser.java:369)
    at com.univocity.parsers.common.AbstractParser.parseNext(AbstractParser.java:595)
    at com.univocity.parsers.common.AbstractParser.internalParseAll(AbstractParser.java:534)
    at com.univocity.parsers.common.AbstractParser.parseAll(AbstractParser.java:527)
    at com.univocity.parsers.common.AbstractParser.parseAll(AbstractParser.java:514)
    at com.springml.spark.salesforce.BulkRelation$$anonfun$3.splitCsvByRows$1(BulkRelation.scala:82)
    at com.springml.spark.salesforce.BulkRelation$$anonfun$3.apply(BulkRelation.scala:96)
    at com.springml.spark.salesforce.BulkRelation$$anonfun$3.apply(BulkRelation.scala:67)
    at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:435)
    at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:441)
    at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
    at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
    at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
    at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$13$$anon$1.hasNext(WholeStageCodegenExec.scala:636)
    at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
    at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
    at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:462)
    at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
    at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
    at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
    at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
    at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
    at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
    at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
    at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$13$$anon$1.hasNext(WholeStageCodegenExec.scala:636)
    at org.apache.spark.sql.execution.datasources.FileFormatWriter$$anonfun$org$apache$spark$sql$execution$datasources$FileFormatWriter$$executeTask$3.apply(FileFormatWriter.scala:244)
    at org.apache.spark.sql.execution.datasources.FileFormatWriter$$anonfun$org$apache$spark$sql$execution$datasources$FileFormatWriter$$executeTask$3.apply(FileFormatWriter.scala:242)
    at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1394)
    at org.apache.spark.sql.execution.datasources.FileFormatWriter$.org$apache$spark$sql$execution$datasources$FileFormatWriter$$executeTask(FileFormatWriter.scala:248)
    ... 10 more
Caused by: java.lang.ArrayIndexOutOfBoundsException: 4096
    at com.univocity.parsers.common.input.DefaultCharAppender.appendUntil(DefaultCharAppender.java:252)
    at com.univocity.parsers.csv.CsvParser.parseQuotedValue(CsvParser.java:335)
    at com.univocity.parsers.csv.CsvParser.parseRecord(CsvParser.java:166)
    at com.univocity.parsers.common.AbstractParser.parseNext(AbstractParser.java:560)
    ... 37 more


The parse "com.univocity.parsers" does have an option to MaxCharPerColumn as unlimited (-1). The end users may face OOM issue for this setting. But Setting to unlimited is much friendly as the fields in Salesforce is so dynamically. We should try to support it as long as physical resource is allowed.