### PR TITLE
Add options to configure size & records of ingest batches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,29 @@ $ bin/spark-shell --packages com.springml:spark-salesforce_2.11:1.1.3
 * `username`: Salesforce Wave Username. This user should have privilege to upload datasets or execute SAQL or execute SOQL  
 * `password`: Salesforce Wave Password. Please append security token along with password.For example, if a user’s password is mypassword, and the security token is XXXXXXXXXX, the user must provide mypasswordXXXXXXXXXX
 * `login`: (Optional) Salesforce Login URL. Default value https://login.salesforce.com
-* `datasetName`: (Optional) Name of the dataset to be created in Salesforce Wave. Required for Dataset Creation
-* `sfObject`: (Optional) Salesforce Object to be updated. (e.g.) Contact. Mandatory if `bulk` is `true`.
+* `sfObject`: (Optional) Salesforce Object to be fetched or updated. (e.g.) Contact. Mandatory if `bulk` is `true`.
 * `metadataConfig`: (Optional) Metadata configuration which will be used to construct [Salesforce Wave Dataset Metadata] (https://resources.docs.salesforce.com/sfdc/pdf/bi_dev_guide_ext_data_format.pdf). Metadata configuration has to be provided in JSON format
 * `saql`: (Optional) SAQL query to used to query Salesforce Wave. Mandatory for reading Salesforce Wave dataset
 * `soql`: (Optional) SOQL query to used to query Salesforce Object. Mandatory for reading Salesforce Object like Opportunity
 * `version`: (Optional) Salesforce API Version. Default 35.0
-* `inferSchema`: (Optional) Inferschema from the query results. Sample rows will be taken to find the datatype
+* `inferSchema`: (Optional) Infer schema from the query results. Sample rows will be taken to find the datatype
 * `dateFormat`: (Optional) A string that indicates the format that follow java.text.SimpleDateFormat to use when reading timestamps. This applies to TimestampType. By default, it is null which means trying to parse timestamp by java.sql.Timestamp.valueOf()
 * `resultVariable`: (Optional) result variable used in SAQL query. To paginate SAQL queries this package will add the required offset and limit. For example, in this SAQL query `q = load \"<dataset_id>/<dataset_version_id>\"; q = foreach q generate  'Name' as 'Name',  'Email' as 'Email';` **q** is the result variable
 * `pageSize`: (Optional) Page size for each query to be executed against Salesforce Wave. Default value is 2000. This option can only be used if `resultVariable` is set
-* `upsert`: (Optional) Flag to upsert data to Salesforce. This performs an insert or update operation using the "externalIdFieldName" as the primary ID. Existing fields that are not in the dataframe being pushed will not be updated. Default "false".
 
 ### Options only supported for fetching Salesforce Objects.
 * `bulk`: (Optional) Flag to enable bulk query. This is the preferred method when loading large sets of data. Salesforce will process batches in the background. Default value is `false`.
 * `pkChunking`: (Optional) Flag to enable automatic primary key chunking for bulk query job. This splits bulk queries into separate batches that of the size defined by `chunkSize` option. By default `false` and the default chunk size is 100,000.
 * `chunkSize`: (Optional) The size of the number of records to include in each batch. Default value is 100,000. This option can only be used when `pkChunking` is `true`. Maximum size is 250,000.
 * `timeout`: (Optional) The maximum time spent polling for the completion of bulk query job. This option can only be used when `bulk` is `true`.
-* `externalIdFieldName`: (Optional) The name of the field used as the external ID for Salesforce Object. This value is only used when doing an update or upsert. Default "Id".
 * `queryAll`: (Optional) Toggle to retrieve deleted and archived records for SOQL queries. Default value is `false`.
+
+### Options only supported for writing Salesforce Objects / Salesforce Wave datasets.
+* `datasetName`: (Optional) Name of the dataset to be created in Salesforce Wave. Required for Dataset Creation
+* `upsert`: (Optional) Flag to upsert data to Salesforce. This performs an insert or update operation using the `externalIdFieldName` as the primary ID. Existing fields that are not in the dataframe being pushed will not be updated. Default "false".
+* `externalIdFieldName`: (Optional) The name of the field used as the external ID for Salesforce Object. This value is only used when doing an update or upsert. Default "Id".
+* `batchSize`: (Optional) The size in bytes per ingest batch. Default value is `10 MB`, maximum size is `10 MB`.
+* `batchRecords`: (Optional) The number of records per ingest batch. Per default only `batchSize` is considered. Maximum number of records per batch is `10,000`.
 
 
 ### Scala API


### PR DESCRIPTION
I've recently run into the ingest record limit (10k). Unfortunately there's no work around due to the repartitioning done here.
This PR adds two configuration options to better control ingest batches:

* `batchSize`: (Optional) The size in bytes per ingest batch. Default value is `10 MB`, maximum size is `10 MB`.
* `batchRecords`: (Optional) The number of records per ingest batch. Per default only `batchSize` is considered. Maximum number of records per batch is `10,000`.

Both are optional and if not set, the behavior remains as is: ingest batches will be up to an estimated 10 MB large despite the number of records.