### PR TITLE
Add CI and maxCharsPerColumn

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,12 +6,10 @@ include:
 ###### common test step #####
 .spark-salesforce-test-info:
   variables:
-    PROJECT_DIRECTORY: "spark-salesforce"
-    SCALA_VERSION: "2.11"
+    PROJECT_DIRECTORY: .
 
 spark-salesforce-test-and-package-2-11:
   variables:
-    PROJECT_DIRECTORY: "spark-salesforce"
     SCALA_VERSION: "2.11"
   extends:
     - .spark-salesforce-test-info
@@ -21,7 +19,6 @@ spark-salesforce-test-and-package-2-11:
 
 spark-salesforce-test-and-package-2-12:
   variables:
-    PROJECT_DIRECTORY: "spark-salesforce"
     SCALA_VERSION: "2.12"
   extends:
     - .spark-salesforce-test-info

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,9 +18,6 @@ spark-salesforce-test-and-package-2-11:
     - .test-and-package-jar
   script:
     - sbt '++ 2.11.12' test package
-  only:
-    changes:
-      - spark-salesforce/**/*
 
 spark-salesforce-test-and-package-2-12:
   variables:
@@ -29,9 +26,6 @@ spark-salesforce-test-and-package-2-12:
   extends:
     - .spark-salesforce-test-info
     - .test-and-package-jar
-  only:
-    changes:
-      - spark-salesforce/**/*
 
 publish spark salesforce:
   stage: publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,9 @@
-
+include:
+  - project: 'slicelife/data-engineering/de-databricks-cicd'
+    ref: v1.30
+    file: 'databricks-jar-gitlab-ci-template.yml'
 
 ###### common test step #####
-# Split this back out if we split into more than a single jar
 .spark-salesforce-test-info:
   variables:
     PROJECT_DIRECTORY: "spark-salesforce"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,48 @@
+
+
+###### common test step #####
+# Split this back out if we split into more than a single jar
+.spark-salesforce-test-info:
+  variables:
+    PROJECT_DIRECTORY: "spark-salesforce"
+    SCALA_VERSION: "2.11"
+
+spark-salesforce-test-and-package-2-11:
+  variables:
+    PROJECT_DIRECTORY: "spark-salesforce"
+    SCALA_VERSION: "2.11"
+  extends:
+    - .spark-salesforce-test-info
+    - .test-and-package-jar
+  script:
+    - sbt '++ 2.11.12' test package
+  only:
+    changes:
+      - spark-salesforce/**/*
+
+spark-salesforce-test-and-package-2-12:
+  variables:
+    PROJECT_DIRECTORY: "spark-salesforce"
+    SCALA_VERSION: "2.12"
+  extends:
+    - .spark-salesforce-test-info
+    - .test-and-package-jar
+  only:
+    changes:
+      - spark-salesforce/**/*
+
+publish spark salesforce:
+  stage: publish
+  extends:
+    - .spark-salesforce-test-info
+    - .test-and-package-jar
+  script:
+    - cat $CI_CRED_TEMPLATE | tee /root/.sbt/.credentials
+    - sbt +publish
+  only:
+    refs:
+      - master
+  except:
+    - schedules
+  allow_failure: false
+

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ $ bin/spark-shell --packages com.springml:spark-salesforce_2.11:1.1.3
 * `pkChunking`: (Optional) Flag to enable automatic primary key chunking for bulk query job. This splits bulk queries into separate batches that of the size defined by `chunkSize` option. By default `false` and the default chunk size is 100,000.
 * `chunkSize`: (Optional) The size of the number of records to include in each batch. Default value is 100,000. This option can only be used when `pkChunking` is `true`. Maximum size is 250,000.
 * `timeout`: (Optional) The maximum time spent polling for the completion of bulk query job. This option can only be used when `bulk` is `true`.
+* `maxCharsPerColumn`(Optional) The maximum length of a column. This option can only be used when `bulk` is `true`. Default value is `4096`.
 * `externalIdFieldName`: (Optional) The name of the field used as the external ID for Salesforce Object. This value is only used when doing an update or upsert. Default "Id".
 * `queryAll`: (Optional) Toggle to retrieve deleted and archived records for SOQL queries. Default value is `false`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "spark-salesforce"
 
 version := "1.1.3"
 
-organization := "com.springml"
+organization := "com.slicelife"
 
 scalaVersion := "2.12.10"
 

--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -34,7 +34,8 @@ case class BulkRelation(
     userSchema: StructType,
     sqlContext: SQLContext,
     inferSchema: Boolean,
-    timeout: Long) extends BaseRelation with TableScan {
+    timeout: Long,
+    maxCharsPerColumn: Int) extends BaseRelation with TableScan {
 
   import sqlContext.sparkSession.implicits._
 
@@ -77,6 +78,7 @@ case class BulkRelation(
           val parserSettings = new CsvParserSettings()
           parserSettings.setLineSeparatorDetectionEnabled(true)
           parserSettings.getFormat.setNormalizedNewline(' ')
+          parserSettings.setMaxCharsPerColumn(maxCharsPerColumn)
 
           val readerParser = new CsvParser(parserSettings)
           val parsedInput = readerParser.parseAll(inputReader).asScala

--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -47,7 +47,6 @@ case class BulkRelation(
     } else {
       records.schema
     }
-
   }
 
   lazy val records: DataFrame = {

--- a/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
@@ -190,6 +190,13 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       throw new Exception("sfObject must not be empty when performing bulk query")
     }
 
+    val maxCharsPerColumnStr = parameters.getOrElse("maxCharsPerColumn", "4096")
+    val maxCharsPerColumn = try {
+      maxCharsPerColumnStr.toInt
+    } catch {
+      case e: Exception => throw new Exception("maxCharsPerColumn must be a valid integer")
+    }
+
     val timeoutStr = parameters.getOrElse("timeout", "600000")
     val timeout = try {
       timeoutStr.toLong
@@ -228,7 +235,8 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       schema,
       sqlContext,
       inferSchemaFlag,
-      timeout
+      timeout,
+      maxCharsPerColumn
     )
   }
 


### PR DESCRIPTION
Changes:

- Slice gitlab CI to build and publish internally
- Additional option of `maxCharsPerColumn` to overcome the internal csv parser default of 4096 characterrs