### PR TITLE
Fix schema inference

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ crossScalaVersions := Seq("2.11.12", "2.12.10")
 resolvers += "sonatype-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
 libraryDependencies ++= Seq(
-  "com.force.api" % "force-wsc" % "40.0.0",
-  "com.force.api" % "force-partner-api" % "40.0.0",
+  "com.force.api" % "force-wsc" % "56.0.0",
+  "com.force.api" % "force-partner-api" % "56.0.0",
   "com.springml" % "salesforce-wave-api" % "1.0.10",
   "org.mockito" % "mockito-core" % "2.0.31-beta"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
+resolvers += "spark-packages" at "https://repos.spark-packages.org/"
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")

--- a/src/main/scala/com/springml/spark/salesforce/DatasetRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/DatasetRelation.scala
@@ -116,7 +116,7 @@ case class DatasetRelation(
 
   private def cast(fieldValue: String, toType: DataType,
       nullable: Boolean = true, fieldName: String): Any = {
-    if (fieldValue == "" && nullable && !toType.isInstanceOf[StringType]) {
+    if ((fieldValue == "" || fieldValue.stripMargin.toLowerCase() == "null") && nullable && !toType.isInstanceOf[StringType]) {
       null
     } else {
       toType match {

--- a/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
@@ -65,7 +65,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     val sampleSize = parameters.getOrElse("sampleSize", "1000")
     val maxRetry = parameters.getOrElse("maxRetry", "5")
     val inferSchema = parameters.getOrElse("inferSchema", "false")
-    val dateFormat = parameters.getOrElse("dateFormat", null)
+    val dateFormat = parameters.getOrElse("dateFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
     // This is only needed for Spark version 1.5.2 or lower
     // Special characters in older version of spark is not handled properly
     val encodeFields = parameters.get("encodeFields")

--- a/src/main/scala/com/springml/spark/salesforce/InferSchema.scala
+++ b/src/main/scala/com/springml/spark/salesforce/InferSchema.scala
@@ -76,6 +76,7 @@ object InferSchema {
         case LongType => tryParseLong(field, sdf)
         case DoubleType => tryParseDouble(field, sdf)
         case TimestampType => tryParseTimestamp(field, sdf)
+        case BooleanType => tryParseBoolean(field)
         case StringType => StringType
         case other: DataType =>
           throw new UnsupportedOperationException(s"Unexpected data type $other")

--- a/src/main/scala/com/springml/spark/salesforce/InferSchema.scala
+++ b/src/main/scala/com/springml/spark/salesforce/InferSchema.scala
@@ -67,7 +67,7 @@ object InferSchema {
    * point checking if it is an Int, as the final type must be Double or higher.
    */
   private def inferField(typeSoFar: DataType, field: String, sdf: SimpleDateFormat): DataType = {
-    if (field == null || field.isEmpty) {
+    if (field == null || field.isEmpty || field.stripMargin.toLowerCase() == "null") {
       typeSoFar
     } else {
       typeSoFar match {


### PR DESCRIPTION
Several issues were present in the original repo's handling of schema inference. Most egregious was a missing `case` statement for `BooleanType` in the `InferSchema` class, but also relevant were incorrect default `Timestamp` handling and a complete lack of handling for the `"null"` Strings that Salesforce likes to return for null fields. This PR fixes all of those issues. 